### PR TITLE
Mute `utils::download.file()` in `download_fh()`

### DIFF
--- a/R/download_functions.R
+++ b/R/download_functions.R
@@ -419,7 +419,7 @@ download_wgi_voice_and_accountability <- function(url,
   Estimate <- wb_country <- year <-  wb_code <- name <- NULL
 
   tmp <- tempfile(fileext = ".xlsx")
-  utils::download.file(url, tmp, mode = "wb")
+  utils::download.file(url, tmp, quiet = !verbose, mode = "wb")
 
   data <- readxl::read_excel(tmp, sheet = 2, skip = 14,
                              .name_repair = "unique_quiet")


### PR DESCRIPTION
Suppresses the output from `utils::download.file()` in [`download_fh()`](https://xmarquez.github.io/democracyData/reference/download_fh.html) when `verbose = FALSE`.

The suppressed output is:

```
trying URL 'https://freedomhouse.org/sites/default/files/2023-02/Country_and_Territory_Ratings_and_Statuses_FIW_1973-2023%20.xlsx'
Content type 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' length 208123 bytes (203 KB)
==================================================
downloaded 203 KB
```